### PR TITLE
support for commonjs \ webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+require('./angular-restheart.module')
+require('./angular-restheart.config')
+
+require('./services/frh.factory')
+require('./services/rh.factory')
+require('./services/rhauth.service')
+require('././services/rhlogic.factory')

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-require('./angular-restheart.module')
-require('./angular-restheart.config')
+require('./angular-restheart.module');
+require('./angular-restheart.config');
 
-require('./services/frh.factory')
-require('./services/rh.factory')
-require('./services/rhauth.service')
-require('././services/rhlogic.factory')
+require('./services/frh.factory');
+require('./services/rh.factory');
+require('./services/rhauth.service');
+require('./services/rhlogic.factory');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-restheart",
   "version": "1.2.4",
   "description": "AngularJs module to handle RESTHeart API properly and easily",
-  "main": "angular-restheart.module.js",
+  "main": "index.js",
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
Please add support for commonjs introducing a index.js file and changing the main file to index.js into the package.js.

With webpack I am unable to import smoothly the angular-restheart library. In order to do it, I singularly import all the required js because of:

1) It's not requirejs compliant
2) in the NPM repository, the dist folder missed

I added a index.js which defines all the requires of the js composed the library.

Thank you :)
